### PR TITLE
Fix url in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     description="An e-commerce product card component for Streamlit",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/msr2903/st-productcard",
+    url="https://github.com/msr2903/st-product-card",
     packages=setuptools.find_packages(where="."),
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
## Summary
- fix `url` in `setup.py`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`


------
https://chatgpt.com/codex/tasks/task_e_68637eacdf08832bb818eb21f7e27a6d